### PR TITLE
Update weatherflowudp.py

### DIFF
--- a/bin/user/weatherflowudp.py
+++ b/bin/user/weatherflowudp.py
@@ -438,7 +438,7 @@ def getStationDevices(token, request_timeout):
     for station in stations:
         for device in station["devices"]:
             if 'serial_number' in device:
-                if device['device_type']=='ST': 
+                if device['device_type']!='HB': # skip Hub devices since they don't have observations
                     device_id_dict.update({device["device_id"]:device["serial_number"]})
                     device_dict.update({device["serial_number"]:device["device_id"]})
     return device_id_dict, device_dict

--- a/bin/user/weatherflowudp.py
+++ b/bin/user/weatherflowudp.py
@@ -476,6 +476,9 @@ def readDataFromWF(start, stop, token, devices, device_dict, batch_size, request
                             log.error(traceback.format_exc())
                             time.sleep(10)
 
+                    # skip this station if it's not valid
+                    if (response.status_code == 500): break
+                      
                     if (response.status_code != 200):
                         raise DriverException("Could not fetch records from WeatherFlow webservice: {}".format(response))
                     jsonResponse = response.json()

--- a/bin/user/weatherflowudp.py
+++ b/bin/user/weatherflowudp.py
@@ -478,7 +478,7 @@ def readDataFromWF(start, stop, token, devices, device_dict, batch_size, request
                             time.sleep(10)
 
                     # skip this station if it's not valid
-                    if (response.status_code == 500): break
+                    if (response.status_code == 500): continue
                       
                     if (response.status_code != 200):
                         raise DriverException("Could not fetch records from WeatherFlow webservice: {}".format(response))

--- a/bin/user/weatherflowudp.py
+++ b/bin/user/weatherflowudp.py
@@ -438,8 +438,9 @@ def getStationDevices(token, request_timeout):
     for station in stations:
         for device in station["devices"]:
             if 'serial_number' in device:
-                device_id_dict.update({device["device_id"]:device["serial_number"]})
-                device_dict.update({device["serial_number"]:device["device_id"]})
+                if device['device_type']=='ST': 
+                    device_id_dict.update({device["device_id"]:device["serial_number"]})
+                    device_dict.update({device["serial_number"]:device["device_id"]})
     return device_id_dict, device_dict
 
 def readDataFromWF(start, stop, token, devices, device_dict, batch_size, request_timeout, min_expected_observation_count, max_retry_count):


### PR DESCRIPTION
I happen to have 2 stations in the WeatherFlow system because one failed and it was replaced under warranty.  I'm not 100% sure this is the right way to fix it, but the code assumes any HTTP return except 200 is a failure, but in my case trying to pull data from the old station that is no longer in service returns a 500 error.  By breaking out of the while loop looking for observations on that error, it lets the code look at and find data from the second (good) station.